### PR TITLE
Do not store excluded fields inside local storage.

### DIFF
--- a/build/form-storage.js
+++ b/build/form-storage.js
@@ -5,7 +5,7 @@
  * form-storage:
  *   license: MIT (http://opensource.org/licenses/MIT)
  *   author: appleple
- *   version: 1.2.1
+ *   version: 1.3.0
  *
  * decode-uri-component:
  *   license: MIT (http://opensource.org/licenses/MIT)
@@ -729,7 +729,8 @@ var defaults = {
   name: 'form',
   ignores: [],
   includes: [],
-  checkbox: null
+  checkbox: null,
+  notPersistedNames: []
 };
 
 var FormStorage = function () {
@@ -749,6 +750,13 @@ var FormStorage = function () {
     key: 'save',
     value: function save() {
       var str = (0, _formSerialize2.default)(this.ele);
+
+      this.opt.notPersistedNames.forEach(function (name) {
+        var regexp = name + '=.*&';
+        var re = new RegExp(regexp, "g");
+        str.replace(re, "");
+      });
+
       window.localStorage.setItem(this.opt.name, str);
     }
   }, {

--- a/build/form-storage.js
+++ b/build/form-storage.js
@@ -750,9 +750,8 @@ var FormStorage = function () {
     key: 'save',
     value: function save() {
       var str = (0, _formSerialize2.default)(this.ele);
-
       this.opt.notPersistedNames.forEach(function (name) {
-        var regexp = encodeURIComponent(name) + '=.*&';
+        var regexp = encodeURIComponent(name) + '=.[^&]*&?';
         var re = new RegExp(regexp, "g");
         str = str.replace(re, "");
       });

--- a/build/form-storage.js
+++ b/build/form-storage.js
@@ -752,9 +752,9 @@ var FormStorage = function () {
       var str = (0, _formSerialize2.default)(this.ele);
 
       this.opt.notPersistedNames.forEach(function (name) {
-        var regexp = name + '=.*&';
+        var regexp = encodeURIComponent(name) + '=.*&';
         var re = new RegExp(regexp, "g");
-        str.replace(re, "");
+        str = str.replace(re, "");
       });
 
       window.localStorage.setItem(this.opt.name, str);

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,9 +43,8 @@ var FormStorage = function () {
     key: 'save',
     value: function save() {
       var str = (0, _formSerialize2.default)(this.ele);
-
       this.opt.notPersistedNames.forEach(function (name) {
-        var regexp = encodeURIComponent(name) + '=.*&';
+        var regexp = encodeURIComponent(name) + '=.[^&]*&?';
         var re = new RegExp(regexp, "g");
         str = str.replace(re, "");
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,9 @@ var FormStorage = function () {
       var str = (0, _formSerialize2.default)(this.ele);
 
       this.opt.notPersistedNames.forEach(function (name) {
-        var regexp = name + '=.*&';
+        var regexp = encodeURIComponent(name) + '=.*&';
         var re = new RegExp(regexp, "g");
-        str.replace(re, "");
+        str = str.replace(re, "");
       });
 
       window.localStorage.setItem(this.opt.name, str);

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,8 @@ var defaults = {
   name: 'form',
   ignores: [],
   includes: [],
-  checkbox: null
+  checkbox: null,
+  notPersistedNames: []
 };
 
 var FormStorage = function () {
@@ -42,6 +43,13 @@ var FormStorage = function () {
     key: 'save',
     value: function save() {
       var str = (0, _formSerialize2.default)(this.ele);
+
+      this.opt.notPersistedNames.forEach(function (name) {
+        var regexp = name + '=.*&';
+        var re = new RegExp(regexp, "g");
+        str.replace(re, "");
+      });
+
       window.localStorage.setItem(this.opt.name, str);
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ const defaults = {
   name: 'form',
   ignores: [],
   includes: [],
-  checkbox: null
+  checkbox: null,
+  notPersistedNames: []
 }
 
 export default class FormStorage {
@@ -22,6 +23,13 @@ export default class FormStorage {
 
   save() {
     const str = serialize(this.ele);
+
+    this.opt.notPersistedNames.forEach((name) => {
+      const regexp = `${name}=.*&`;
+      const re = new RegExp(regexp, "g");
+      str.replace(re, "")
+    });
+
     window.localStorage.setItem(this.opt.name, str);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,12 +22,12 @@ export default class FormStorage {
   }
 
   save() {
-    const str = serialize(this.ele);
+    let str = serialize(this.ele);
 
     this.opt.notPersistedNames.forEach((name) => {
-      const regexp = `${name}=.*&`;
+      const regexp = `${encodeURIComponent(name)}=.*&`;
       const re = new RegExp(regexp, "g");
-      str.replace(re, "")
+      str = str.replace(re, "")
     });
 
     window.localStorage.setItem(this.opt.name, str);

--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,8 @@ export default class FormStorage {
 
   save() {
     let str = serialize(this.ele);
-
     this.opt.notPersistedNames.forEach((name) => {
-      const regexp = `${encodeURIComponent(name)}=.*&`;
+      const regexp = `${encodeURIComponent(name)}=.[^&]*&?`;
       const re = new RegExp(regexp, "g");
       str = str.replace(re, "")
     });


### PR DESCRIPTION
Because of the security reasons it's not good to store things like password or user name in local storage when they are marked as excluded.

This fix completely ignores the fields and do not store them in localStorage if they are inside notPersistedNames.